### PR TITLE
Fix unclosed asyncpg connections causing SQLAlchemy pool warnings (#65)

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -73,11 +73,11 @@ Base = declarative_base()
 
 # Async dependency
 async def get_async_db():
-    async with AsyncSessionLocal() as session:
-        try:
-            yield session
-        finally:
-            await session.close()
+    session = AsyncSessionLocal()
+    try:
+        yield session
+    finally:
+        await session.close()
 
 
 @asynccontextmanager
@@ -89,8 +89,6 @@ async def get_db_session():
         except Exception:
             await session.rollback()
             raise
-        finally:
-            await session.close()
 
 
 def get_connection_info():

--- a/tests/cache/test_async_cache.py
+++ b/tests/cache/test_async_cache.py
@@ -534,7 +534,7 @@ async def test_async_cache_warming():
                 hashed_password="dummy_hash",
             )
             db.add(user)
-            db.commit()
+            await db.commit()
 
             # Create a test API key
             test_api_key = "test_key_123"
@@ -546,7 +546,7 @@ async def test_async_cache_warming():
                 encrypted_api_key=encrypted_key,
             )
             db.add(provider_key)
-            db.commit()
+            await db.commit()
 
             # Warm the cache
             await warm_cache_async(db)

--- a/tests/mock_testing/add_mock_provider.py
+++ b/tests/mock_testing/add_mock_provider.py
@@ -55,7 +55,7 @@ async def setup_mock_provider(username: str, force: bool = False):
             # If force is set and provider exists, delete the existing one
             if existing_provider and force:
                 db.delete(existing_provider)
-                db.commit()
+                await db.commit()
                 print(f"🗑️ Deleted existing mock provider for user '{username}'.")
 
             # Create a mock API key - it doesn't need to be secure as it's not used
@@ -83,7 +83,7 @@ async def setup_mock_provider(username: str, force: bool = False):
             )
 
             db.add(provider_key)
-            db.commit()
+            await db.commit()
 
             # Invalidate provider key cache for this user to force refresh
             provider_service_cache.delete(f"provider_keys:{user.id}")


### PR DESCRIPTION
- Apply recommended fix to get_async_db(): use explicit session management instead of async context manager
- Remove redundant session.close() in get_db_session() after async with block
- Fix synchronous commit() calls on async sessions in test files
- Ensures proper cleanup of database connections and prevents pool exhaustion


Let me know if this is sufficient. I think swapping to await db.commit() is better, but let me know.


should fix Issue (#65)