### PR TITLE
Tune gunicorn lifecycle for streaming requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,5 @@ USER nobody
 # Expose port
 EXPOSE 8000
 
-# Use environment variable for workers count and optimize for database connections
-CMD ["sh", "-c", "gunicorn app.main:app -k uvicorn.workers.UvicornWorker --workers ${WORKERS:-5} --bind 0.0.0.0:8000 --timeout 120 --max-requests 1000 --max-requests-jitter 100"]
+# Use Gunicorn config so worker lifecycle settings are explicit and env-overridable.
+CMD ["gunicorn", "app.main:app", "--config", "gunicorn_conf.py"]

--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -1,0 +1,21 @@
+import os
+
+
+def _int_env(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    return int(value)
+
+
+bind = f"0.0.0.0:{os.getenv('PORT', '8000')}"
+worker_class = "uvicorn.workers.UvicornWorker"
+workers = _int_env("WORKERS", 5)
+
+# Long provider streams should not be interrupted by the default 30s graceful
+# shutdown window, and workers should not recycle while streaming requests run.
+timeout = _int_env("GUNICORN_TIMEOUT", 300)
+graceful_timeout = _int_env("GUNICORN_GRACEFUL_TIMEOUT", 300)
+keepalive = _int_env("GUNICORN_KEEPALIVE", 75)
+max_requests = _int_env("GUNICORN_MAX_REQUESTS", 0)
+max_requests_jitter = _int_env("GUNICORN_MAX_REQUESTS_JITTER", 0)


### PR DESCRIPTION
## Summary
- Move Gunicorn runtime settings into `gunicorn_conf.py` so lifecycle parameters are explicit and env-overridable.
- Increase request and graceful shutdown timeouts to 300s for long provider streams.
- Disable `max_requests` worker recycling by default to avoid interrupting streaming `/v1/chat/completions` requests.

## Context
Railway HTTP logs showed many `/v1/chat/completions` 502s with upstream `connection closed unexpectedly`. The old deployment also showed repeated `Maximum request limit ... Terminating process` events, which can recycle workers while streaming requests are active.

## Validation
- `python3 -m py_compile gunicorn_conf.py`
- Loaded `gunicorn_conf.py` locally and confirmed defaults: `timeout=300`, `graceful_timeout=300`, `keepalive=75`, `max_requests=0`, `max_requests_jitter=0`.
- `git diff --check HEAD~1..HEAD`